### PR TITLE
Add RiotWindowClass to disallowedClasses to fix issue with Leauge of …

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Resizer 2"
-#define MyAppVersion "2.0.2"
+#define MyAppVersion "2.0.3"
 #define MyAppPublisher "Alve Svarén"
 #define MyAppURL "https://github.com/alvesvaren/resizer2"
 #define MyAppExeName "resizer2-portable.exe"

--- a/resizer2/resizer2.h
+++ b/resizer2/resizer2.h
@@ -44,6 +44,7 @@ const std::unordered_set<std::wstring> disallowedClasses{
 	L"Shell_TrayWnd",
 	L"Progman",
 	L"WorkerW",
+    L"RiotWindowClass"
 };
 
 enum ContextType {


### PR DESCRIPTION
…legends

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `RiotWindowClass` to `disallowedClasses` and updates installer version to 2.0.3.
> 
> - **Core**:
>   - Add `RiotWindowClass` to `disallowedClasses` in `resizer2/resizer2.h`.
> - **Installer**:
>   - Bump `MyAppVersion` to `2.0.3` in `installer.iss`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dfbb3a612894685774a7234fbd9192e5eab71a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->